### PR TITLE
Readability suggestions

### DIFF
--- a/guidelines/1.3.3.md
+++ b/guidelines/1.3.3.md
@@ -2,7 +2,7 @@ This document is in beta. Help us by [reporting issues via Github](https://githu
 
 [Back to the overview page](./../index.html)
 
-# Instructions don't rely on sensory characteristics
+# Instructions should not rely on sensory characteristics
 
 On this page:
 * [Summary](#summary)
@@ -14,7 +14,7 @@ On this page:
 
 ## Summary
 
-**If you give tips or instructions, don't assume that users can perceive colour, size, shape, sound or the location of elements on screen.**
+**If you give tips or instructions, do not assume that users can perceive colour, size, shape, sound or the location of elements on screen.**
 
 Instructions must not depend on sensory characteristics like shape, size, colour, or location.
 


### PR DESCRIPTION
removed contracted negative of "don't" in 2 occurrences 
and replaced with "do not" and "should not"
these are per recommendations from Readability Guidelines (https://readabilityguidelines.co.uk/grammar-points/contractions/)