### PR TITLE
K+C copyright updates + email changes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 TAB
+Copyright (c) 2020 Kin + Carta
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [See the guidelines](https://theappbusiness.github.io/accessibility-guidelines/)
 
-**This document is in beta**. Please help by reporting issues via Github or [email](mailto:jeanfrancois@theappbusiness.com), or contributing content.
+**This document is in beta**. Please help by reporting issues via Github or [email](mailto:a11y@kinandcarta.com), or contributing content.

--- a/guidelines/1.1.1.md
+++ b/guidelines/1.1.1.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -89,7 +89,7 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
   - When charts or graphs are used to display information that (that is, data with internal relationships that could naturally represented in a table), the same data is shown in a correctly marked-up table.
 - Verbose alternatives make content harder to listen to and understand for screen reader users. Endeavour to be succinct, and avoid redundant phrasing such as "Picture of ...", "... logo", or "Select this to ...".
 
-This section needs one or more examples. [Contribute or report issues via Github](https://github.com/theappbusiness/accessibility-guidelines/issues/51) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs one or more examples. [Contribute or report issues via Github](https://github.com/theappbusiness/accessibility-guidelines/issues/51) or [email](mailto:a11y@kinandcarta.com).
 
 ### More guidance for design
 
@@ -235,4 +235,4 @@ imageView.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.2.1-audio-only.md
+++ b/guidelines/1.2.1-audio-only.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -59,4 +59,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.2.2.md
+++ b/guidelines/1.2.2.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -57,4 +57,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.2.3.md
+++ b/guidelines/1.2.3.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -61,4 +61,4 @@ Note: pre-recorded videos without sound are covered somewhere else in the W3C We
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.2.4.md
+++ b/guidelines/1.2.4.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -54,4 +54,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.2.5.md
+++ b/guidelines/1.2.5.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -62,4 +62,4 @@ Note: pre-recorded videos without sound are covered somewhere else in the W3C We
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.3.1.md
+++ b/guidelines/1.3.1.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -55,7 +55,7 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ## Guidance for Design
 
-This section needs more content. [Contribute via Github issue](https://github.com/theappbusiness/accessibility-guidelines/issues/58) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github issue](https://github.com/theappbusiness/accessibility-guidelines/issues/58) or [email](mailto:a11y@kinandcarta.com).
 
 ### More guidance for design
 
@@ -296,7 +296,7 @@ TextField(
 
 ## Guidance for Web
 
-This section needs a review and more content. [Contribute or report issues via Github](https://github.com/theappbusiness/accessibility-guidelines/issues/59) (preferred) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs a review and more content. [Contribute or report issues via Github](https://github.com/theappbusiness/accessibility-guidelines/issues/59) (preferred) or [email](mailto:a11y@kinandcarta.com).
 
 ### Forming a correct headings structure
 
@@ -585,4 +585,4 @@ This section needs a review and more content. [Contribute or report issues via G
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.3.2.md
+++ b/guidelines/1.3.2.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -71,8 +71,6 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
     * But on the design for small screens, the 'Cancel' button is positioned to the bottom of the 'OK' button. ('Cancel' now comes after 'OK' in the reading order).
 
 ### More guidance for design
-
-* [Annotating designs for accessibility](https://drive.google.com/file/d/1n0DkLoFydmbNxLisivqHh8xoo467HgBJ/view?usp=sharing) by Henny Swan at TPG
 
 ---
 
@@ -267,4 +265,4 @@ Column(
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.3.3.md
+++ b/guidelines/1.3.3.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -60,4 +60,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.3.4.md
+++ b/guidelines/1.3.4.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -190,7 +190,7 @@ void dispose() {
 
 ## Guidance for Web
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ### More guidance for Web
 
@@ -213,4 +213,4 @@ This section needs more content. [Contribute via Github](https://github.com/thea
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.3.5.md
+++ b/guidelines/1.3.5.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -33,7 +33,7 @@ Note that if the input field was not collecting information about the user thems
 
 ### Requirements for both native and web
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ### Web only requirements
 
@@ -59,7 +59,7 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/WAI/WC
 
 ## Guidance for Design
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -236,4 +236,4 @@ Here's an example of a form collecting data on a user with autocomplete attribut
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.4.1.md
+++ b/guidelines/1.4.1.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -104,19 +104,19 @@ Additional visual and non-visual methods of identifying information or meaning m
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Android
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Flutter
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jacek.kulinski@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -137,4 +137,4 @@ This section needs more content. [Contribute via Github](https://github.com/thea
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.4.10.md
+++ b/guidelines/1.4.10.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -66,7 +66,7 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/WAI/WC
 
 ## Guidance for Design
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -148,7 +148,7 @@ scrollDirection: Axis.enum, // defaults to Axis.vertical
 
 See the [W3C's detailed explanation of this guideline](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html) with techniques and examples.
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ### Displaying code
 
@@ -165,4 +165,4 @@ The use of &lt;code&gt;&lt;pre&gt; formatted content (such as code) can cause ho
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.4.11.md
+++ b/guidelines/1.4.11.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -118,4 +118,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.4.12.md
+++ b/guidelines/1.4.12.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -78,7 +78,7 @@ See the [W3C's detailed explanation of this guideline](LINK) with techniques and
 
 ## Guidance for Design
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 In the meantime, see the [W3C's detailed explanation of this guideline](https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html) with techniques and examples.
 
@@ -86,7 +86,7 @@ In the meantime, see the [W3C's detailed explanation of this guideline](https://
 
 ## Guidance for Web
 
-This section needs a review and more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs a review and more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 In the meantime, see the [W3C's detailed explanation of this guideline](https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html) with techniques and examples.
 
@@ -109,4 +109,4 @@ In the meantime, see the [W3C's detailed explanation of this guideline](https://
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.4.13.md
+++ b/guidelines/1.4.13.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -83,4 +83,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/WAI/WC
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.4.2.md
+++ b/guidelines/1.4.2.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -71,4 +71,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.4.3.md
+++ b/guidelines/1.4.3.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -64,4 +64,4 @@ User tools like Sketch's Stark plug-in, [Colour Contrast Analyser](https://devel
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.4.4.md
+++ b/guidelines/1.4.4.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -49,7 +49,7 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ## Guidance for Design
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/issues/58) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/issues/58) or [email](mailto:a11y@kinandcarta.com).
 
 ### More guidance for design
 
@@ -59,7 +59,7 @@ This section needs more content. [Contribute via Github](https://github.com/thea
 
 ## Guidance for Design
 
-This section more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -106,7 +106,7 @@ override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollect
 - [UILabel developer reference](https://developer.apple.com/documentation/uikit/uilabel "developer.apple.com reference")
 - [UIStackView developer reference](https://developer.apple.com/documentation/uikit/uistackview "developer.apple.com reference")
 - [UITraitEnvironment developer reference](https://developer.apple.com/documentation/uikit/uitraitenvironment "developer.apple.com reference")
-- [Snapshot testing Dynamic Type](https://edit.theappbusiness.com/snapshot-testing-dynamic-type-74119ee36042 "Article on how to snapshot test Dynamic Type")
+- [Snapshot testing Dynamic Type](https://medium.com/kinandcartacreated/snapshot-testing-dynamic-type-74119ee36042 "Article on how to snapshot test Dynamic Type")
 
 ---
 
@@ -222,4 +222,4 @@ Container(
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/1.4.5.md
+++ b/guidelines/1.4.5.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -56,4 +56,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.1.1.md
+++ b/guidelines/2.1.1.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -53,7 +53,7 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ## Guidance for Design
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UNDERSTANDING-WCAG20/keyboard-operation-keyboard-operable.html) with techniques and examples.
 
@@ -61,19 +61,19 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Android
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Flutter
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jacek.kulinski@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -172,4 +172,4 @@ Listening for touch gestures without providing equivalent control via keyboard:
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.1.2.md
+++ b/guidelines/2.1.2.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -58,7 +58,6 @@ This will help make sure that components such as dialogs can be closed easily by
 
 ### More guidance for Design
 
-* [Annotating designs for accessibility](https://drive.google.com/file/d/1n0DkLoFydmbNxLisivqHh8xoo467HgBJ/view?usp=sharing) by Henny Swan at TPG
 * [Modal dialog example](https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html) in the ARIA Authoring Practices Guide
 * See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UNDERSTANDING-WCAG20/keyboard-operation-trapping.html) with techniques and examples.
 
@@ -66,19 +65,19 @@ This will help make sure that components such as dialogs can be closed easily by
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Android
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Flutter
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jacek.kulinski@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -140,4 +139,4 @@ function check() {
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.1.4.md
+++ b/guidelines/2.1.4.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -70,4 +70,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/WAI/WC
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.2.1.md
+++ b/guidelines/2.2.1.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -66,7 +66,7 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 
 

--- a/guidelines/2.2.2.md
+++ b/guidelines/2.2.2.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -92,4 +92,4 @@ A moving carousel of news stories that change every 5 seconds:
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.3.1.md
+++ b/guidelines/2.3.1.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -51,4 +51,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.4.1.md
+++ b/guidelines/2.4.1.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -101,4 +101,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.4.2.md
+++ b/guidelines/2.4.2.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -70,13 +70,13 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Android
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -105,7 +105,7 @@ From a user's perspective, it doesn't matter to them whether they're visiting a 
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 
 

--- a/guidelines/2.4.3.md
+++ b/guidelines/2.4.3.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -83,13 +83,12 @@ This will help make sure that components such as dialogs can be closed easily by
 ### More guidance for design
 
 * [Placing the interactive elements in an order that follows sequences and relationships within the content](https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/G59) technique in the Web Content Accessibility Guidelines
-* [Annotating designs for accessibility](https://drive.google.com/file/d/1n0DkLoFydmbNxLisivqHh8xoo467HgBJ/view?usp=sharing) by Henny Swan at TPG
 
 ---
 
 ## Guidance for iOS
 
-This section needs a review and more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs a review and more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -140,7 +139,7 @@ The best practices for grouping and ordering elements in an accessible manner ca
 </LinearLayout>
 ```
 
-This section needs a review and more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs a review and more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -315,4 +314,4 @@ TextField(
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.4.4.md
+++ b/guidelines/2.4.4.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -104,13 +104,13 @@ label.accessibilityHint = "Select to be taken to example.com"
 
 ## Guidance for Android
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/issues/58) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/issues/58) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Flutter
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/issues/58) or [email](mailto:jacek.kulinski@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/issues/58) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -201,5 +201,5 @@ You can use a `.visually-hidden` CSS class to extend a link's name without lengt
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 

--- a/guidelines/2.4.5.md
+++ b/guidelines/2.4.5.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -50,4 +50,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.4.6.md
+++ b/guidelines/2.4.6.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -69,4 +69,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.4.7.md
+++ b/guidelines/2.4.7.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -72,19 +72,19 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Android
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Flutter
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jacek.kulinski@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -156,4 +156,4 @@ But the [`:focus-visible` polyfill](https://wicg.github.io/focus-visible/explain
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.5.1.md
+++ b/guidelines/2.5.1.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -65,4 +65,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/WAI/WC
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.5.2.md
+++ b/guidelines/2.5.2.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -56,13 +56,13 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/WAI/WC
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Android
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ### More guidance for Android
 
@@ -72,7 +72,7 @@ This section needs more content. [Contribute via Github](https://github.com/thea
 
 ## Guidance for Flutter
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jacek.kulinski@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -98,4 +98,4 @@ Using click events will only trigger the event on release.
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.5.3.md
+++ b/guidelines/2.5.3.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -79,25 +79,25 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/WAI/WC
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Android
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Flutter
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jacek.kulinski@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Web
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ### More guidance for Web
 
@@ -114,4 +114,4 @@ This section needs more content. [Contribute via Github](https://github.com/thea
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.5.4.md
+++ b/guidelines/2.5.4.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -62,4 +62,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/WAI/WC
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/2.6.1.md
+++ b/guidelines/2.6.1.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:alexander.newnham@kinandcarta.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -52,13 +52,13 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/mob
 
 ## Guidance for Design
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:talia.craiu@kinandcarta.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@kinandcarta.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -113,13 +113,13 @@ Enable [developer options](https://developer.android.com/studio/debug/dev-option
 
 ## Guidance for Flutter
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jacek.kulinski@kinandcarta.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Web
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:alexander.newnham@kinandcarta.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -131,5 +131,5 @@ This section needs more content. [Contribute via Github](https://github.com/thea
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:alexander.newnham@kinandcarta.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 

--- a/guidelines/3.1.1.md
+++ b/guidelines/3.1.1.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -50,19 +50,19 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Android
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Flutter
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -119,7 +119,7 @@ Note: It's better to only use the two-letter code representing the language (lik
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 
 

--- a/guidelines/3.1.2.md
+++ b/guidelines/3.1.2.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -61,7 +61,7 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -87,7 +87,7 @@ return spannable
 
 ## Guidance for Flutter
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jacek.kulinski@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -154,4 +154,4 @@ Note: It's better to only use the two-letter code representing the language (lik
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/3.2.1.md
+++ b/guidelines/3.2.1.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -62,19 +62,19 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Android
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Flutter
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jacek.kulinski@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -99,4 +99,4 @@ This section needs more content. [Contribute via Github](https://github.com/thea
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/3.2.2.md
+++ b/guidelines/3.2.2.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -86,19 +86,19 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Android
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for Flutter
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jacek.kulinski@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -137,4 +137,4 @@ This section needs more content. [Contribute via Github](https://github.com/thea
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/3.2.3.md
+++ b/guidelines/3.2.3.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -47,4 +47,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/3.2.4.md
+++ b/guidelines/3.2.4.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -68,4 +68,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/3.3.1.md
+++ b/guidelines/3.3.1.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -60,7 +60,7 @@ For example, when a form is submitted:
 
 3. form inputs that are in error are identified both visually (using than colour alone) and in code (using `aria-invalid` for example).
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ### More guidance for design
 
@@ -71,7 +71,7 @@ This section needs more content. [Contribute via Github](https://github.com/thea
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -100,7 +100,7 @@ Options for this attribute are the following:
 
 ## Guidance for Flutter
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jacek.kulinski@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -148,4 +148,4 @@ aria-describedby="national-insurance-number-hint national-insurance-number-error
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/3.3.2.md
+++ b/guidelines/3.3.2.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -78,7 +78,7 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -234,4 +234,4 @@ Make sure that you closely follow the ['Radio Group' pattern in the ARIA Authori
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/3.3.3.md
+++ b/guidelines/3.3.3.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -47,7 +47,7 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ## Guidance for Design
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ### More guidance for design
 
@@ -57,7 +57,7 @@ This section needs more content. [Contribute via Github](https://github.com/thea
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -96,7 +96,7 @@ if (hasErrors == true) {
 
 ## Guidance for Flutter
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jacek.kulinski@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -138,4 +138,4 @@ aria-describedby="national-insurance-number-hint national-insurance-number-error
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/3.3.4.md
+++ b/guidelines/3.3.4.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -50,7 +50,7 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ## Guidance for Design
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ### More guidance for design
 
@@ -68,4 +68,4 @@ This section needs more content. [Contribute via Github](https://github.com/thea
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/4.1.1.md
+++ b/guidelines/4.1.1.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -65,4 +65,4 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/4.1.2.md
+++ b/guidelines/4.1.2.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -55,17 +55,15 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/TR/UND
 
 ## Guidance for Design
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ### More guidance for design
-
-- [Annotating designs for accessibility](https://drive.google.com/a/theappbusiness.com/file/d/1n0DkLoFydmbNxLisivqHh8xoo467HgBJ/view?usp=sharing) by Henny Swan and The Paciello Group
 
 ---
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -309,4 +307,4 @@ For example, let's imagine that you're building a button using `div role="button
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)

--- a/guidelines/4.1.3.md
+++ b/guidelines/4.1.3.md
@@ -1,4 +1,4 @@
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 
 [Back to the overview page](./../index.html)
 
@@ -49,13 +49,13 @@ See the [W3C's detailed explanation of this guideline](https://www.w3.org/WAI/WC
 
 ## Guidance for Design
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:jeanfrancois@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
 ## Guidance for iOS
 
-This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:kane.cheshire@theappbusiness.com).
+This section needs more content. [Contribute via Github](https://github.com/theappbusiness/accessibility-guidelines/) or [email](mailto:a11y@kinandcarta.com).
 
 ---
 
@@ -155,5 +155,5 @@ You can use the following techniques:
 
 ### Contribute
 
-This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:jeanfrancois@theappbusiness.com)
+This document is in beta. Help us by [reporting issues via Github](https://github.com/theappbusiness/accessibility-guidelines) or [email](mailto:a11y@kinandcarta.com)
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 
   <body>
     <header>
-      <p>This document is in beta. Help us by <a href="https://github.com/theappbusiness/accessibility-guidelines">reporting issues via Github</a> or <a href="mailto:jeanfrancois@theappbusiness.com">email</a>.</p>
+      <p>This document is in beta. Help us by <a href="https://github.com/theappbusiness/accessibility-guidelines">reporting issues via Github</a> or <a href="mailto:a11y@kinandcarta.com">email</a>.</p>
       
       <p>v0.8.0. See the <a href="https://jfhector.github.io/accessibility-guidelines/">latest version</a>.</p>
       


### PR DESCRIPTION
Updated TAB email references to point to a shared mailbox and removed  broken links to Google Drive doc on Annotating Designs.

Also updated copyright in LICENSE and fixed a blog link to point to K+C instead of TABs blog.