### PR TITLE
Remove unnecessary external guideline references

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,9 +10,7 @@
   <body>
     <header>
       <p>This document is in beta. Help us by <a href="https://github.com/theappbusiness/accessibility-guidelines">reporting issues via Github</a> or <a href="mailto:a11y@kinandcarta.com">email</a>.</p>
-      
-      <p>v0.8.0. See the <a href="https://jfhector.github.io/accessibility-guidelines/">latest version</a>.</p>
-      
+            
       <h1>Accessibility Guidelines Summary</h1>
   
       <p>This document provided by <a href="https://www.kinandcarta.com/">Kin + Carta Create</a> will help you quickly get up to speed with the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines (WCAG) 2.1</a>, and avoid common accessibility mistakes.</p>

--- a/index.html
+++ b/index.html
@@ -643,6 +643,9 @@
           <a href="http://www.bbc.co.uk/guidelines/futuremedia/accessibility/mobile">BBC</a>
         </li>
       </ul>
+
+      <h2 id="sources_list">Document version</h2>
+      <p>v0.8.0</p>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
### Why?

Guidelines were redirecting to a temporary fork, which is no longer needed.

### What?

Deleted the link and versioning (we're not using it). 